### PR TITLE
Make admin role toggle options prettier

### DIFF
--- a/frontend/src/main/components/Users/UsersTable.js
+++ b/frontend/src/main/components/Users/UsersTable.js
@@ -105,9 +105,9 @@ export default function UsersTable({ users}) {
 
     const buttonColumn = [
         ...columns,
-        ButtonColumn("toggle-admin", "primary", toggleAdminCallback, "UsersTable"),
-        ButtonColumn("toggle-driver", "primary", toggleDriverCallback, "UsersTable"),
-        ButtonColumn("toggle-rider", "primary", toggleRiderCallback, "UsersTable")
+        ButtonColumn("Toggle Admin", "warning", toggleAdminCallback, "UsersTable"),
+        ButtonColumn("Toggle Driver", "success", toggleDriverCallback, "UsersTable"),
+        ButtonColumn("Toggle Rider", "primary", toggleRiderCallback, "UsersTable")
     ]
 
     //const columnsToDisplay = showButtons ? buttonColumn : columns;

--- a/frontend/src/tests/pages/AdminUsersPage.test.js
+++ b/frontend/src/tests/pages/AdminUsersPage.test.js
@@ -82,7 +82,7 @@ describe("AdminUsersPage tests", () => {
         );
         await waitFor(() => expect(getByText("Users")).toBeInTheDocument());
 
-        const toggleAdminButton = screen.getByTestId(`${testId}-cell-row-0-col-toggle-admin-button`);
+        const toggleAdminButton = screen.getByTestId(`${testId}-cell-row-0-col-Toggle Admin-button`);
         expect(toggleAdminButton).toBeInTheDocument();
 
         fireEvent.click(toggleAdminButton);
@@ -108,7 +108,7 @@ describe("AdminUsersPage tests", () => {
         );
         await waitFor(() => expect(getByText("Users")).toBeInTheDocument());
 
-        const toggleDriverButton = screen.getByTestId(`${testId}-cell-row-0-col-toggle-driver-button`);
+        const toggleDriverButton = screen.getByTestId(`${testId}-cell-row-0-col-Toggle Driver-button`);
         expect(toggleDriverButton).toBeInTheDocument();
 
         fireEvent.click(toggleDriverButton);
@@ -133,7 +133,7 @@ describe("AdminUsersPage tests", () => {
         );
         await waitFor(() => expect(getByText("Users")).toBeInTheDocument());
 
-        const toggleRiderButton = screen.getByTestId(`${testId}-cell-row-0-col-toggle-rider-button`);
+        const toggleRiderButton = screen.getByTestId(`${testId}-cell-row-0-col-Toggle Rider-button`);
         expect(toggleRiderButton).toBeInTheDocument();
 
         fireEvent.click(toggleRiderButton);


### PR DESCRIPTION
### Things Done

- [x] The headers should be capitalized and not have the dash anymore
- [x] The buttons should be capitalized and not have the dash anymore
- [x] Optional: Distinguish between the buttons by changing their colors

In this PR, we edited UsersTable so that the buttons for changing admin, driver, and rider are capitalized, without dashes, and are different colors for easier differentiating.

Before:
![AdminOptionsOld](https://github.com/ucsb-cs156-w24/proj-gauchoride-w24-7pm-3/assets/64328234/dd726cde-5424-4b7c-a4c2-74fceec80e04)

After:
![AdminOptionsNew](https://github.com/ucsb-cs156-w24/proj-gauchoride-w24-7pm-3/assets/64328234/36d51875-27aa-45d7-9e3a-9bafd76fb21a)

Closes #2 