### PR TITLE
feat: add driverAvailability entity and driverAvailabilityFixtures an…

### DIFF
--- a/frontend/src/fixtures/driverAvailabilityFixtures.js
+++ b/frontend/src/fixtures/driverAvailabilityFixtures.js
@@ -1,0 +1,40 @@
+const driverAvailabilityFixtures = {
+    oneAvailability: [
+        {
+            id: 1,
+            driverId: 1,
+            day: "Monday",
+            startTime: "3:30PM",
+            endTime: "4:45PM",
+            notes: "Available for short trips"
+        }
+    ],
+    threeAvailabilities: [
+        {
+            id: 2,
+            driverId: 2,
+            day: "Tuesday",
+            startTime: "5:00PM",
+            endTime: "5:50PM",
+            notes: "Evening shifts preferred"
+        },
+        {
+            id: 3,
+            driverId: 3,
+            day: "Wednesday",
+            startTime: "11:00AM",
+            endTime: "11:15AM",
+            notes: "Brief midday availability"
+        },
+        {
+            id: 4,
+            driverId: 4,
+            day: "Thursday",
+            startTime: "4:15PM",
+            endTime: "5:30PM",
+            notes: "Available for longer afternoon to evening shifts"
+        }
+    ]
+};
+
+export { driverAvailabilityFixtures };

--- a/src/main/java/edu/ucsb/cs156/gauchoride/entities/DriverAvailability.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/entities/DriverAvailability.java
@@ -1,0 +1,34 @@
+package edu.ucsb.cs156.gauchoride.entities;
+
+import javax.persistence.Entity;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import javax.persistence.GeneratedValue;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "driverAvailability")
+public class DriverAvailability {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  private long driverId;
+
+  @Schema(allowableValues = "Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday")
+  private String day;
+  
+  private String startTime; // format: HH:MM(A/P)M e.g. "11:00AM" or "1:37PM"
+  private String endTime; // format: HH:MM(A/P)M e.g. "11:00AM" or "1:37PM"
+  private String notes;
+}

--- a/src/main/java/edu/ucsb/cs156/gauchoride/repositories/DriverAvailabilityRepository.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/repositories/DriverAvailabilityRepository.java
@@ -1,0 +1,13 @@
+package edu.ucsb.cs156.gauchoride.repositories;
+
+import edu.ucsb.cs156.gauchoride.entities.DriverAvailability;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+import java.util.Optional;
+
+@Repository
+public interface DriverAvailabilityRepository extends CrudRepository<DriverAvailability, Long> {
+  Iterable<DriverAvailability> findAllByDriverId(long driverId);
+  Optional<DriverAvailability> findByIdAndDriverId(long id, long driverId);
+}


### PR DESCRIPTION
In this PR, we added the driverAvailability entity that holds the information for a driver availability entry as well as driverAvailability fixtures for testing.

### Database record and fixtures for driverAvailability

- [x] There is an `@Entity` called DriverAvailability with fields: `Long id`, (type depends) `driverId`, `String day`, `String startTime`, `String endTime`, `String notes`.
- [x] There is a `@Repository` called `DriverAvailabilityRepository`.
- [x] There is a fixtures file `driverAvailabilityFixtures.js`.

Closes #16 