### PR TITLE
Driver Availability: Add controller GET all endpoint for driver availability and tests

### DIFF
--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityController.java
@@ -28,7 +28,6 @@ import javax.validation.Valid;
 @Tag(name = "DriverAvailability Request")
 @RequestMapping("/api/driverAvailability")
 @RestController
-
 public class DriverAvailabilityController extends ApiController {
 
     @Autowired
@@ -102,5 +101,14 @@ public class DriverAvailabilityController extends ApiController {
         
         return genericMessage("DriverAvailability with id %s deleted".formatted(id));
     }
+    @Operation(summary = "List all availabilities of current user")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public Iterable<DriverAvailability> allUserDriverAvailabilities() {
+        Iterable<DriverAvailability> availabilities;
+        availabilities = driverAvailabilityRepository.findAllByDriverId(getCurrentUser().getUser().getId());
+        return availabilities;
+    }
+
 }
 

--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityController.java
@@ -27,7 +27,7 @@ import javax.validation.Valid;
 
 @Tag(name = "DriverAvailability Request")
 @RequestMapping("/api/driverAvailability")
-@RestController
+    @RestController
 public class DriverAvailabilityController extends ApiController {
 
     @Autowired
@@ -101,8 +101,9 @@ public class DriverAvailabilityController extends ApiController {
         
         return genericMessage("DriverAvailability with id %s deleted".formatted(id));
     }
+    
     @Operation(summary = "List all availabilities of current user")
-    @PreAuthorize("hasRole('ROLE_USER')")
+    @PreAuthorize("hasRole('ROLE_DRIVER')")
     @GetMapping("")
     public Iterable<DriverAvailability> allUserDriverAvailabilities() {
         Iterable<DriverAvailability> availabilities;

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityControllerTests.java
@@ -270,5 +270,39 @@ public class DriverAvailabilityControllerTests extends ControllerTestCase {
         String responseString = response.getResponse().getContentAsString();
         assertEquals(expectedJson, responseString);
     }
+
+    @Test
+    public void kappachungusfailshahahalol() throws Exception {
+            mockMvc.perform(get("/api/driverAvailability"))
+                            .andExpect(status().is(403)); // logged out users can't get all
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void hehehhahah() throws Exception {
+        // arrange
+        DriverAvailability availability1 = new DriverAvailability();
+        availability1.setId(1L);
+        availability1.setDriverId(currentUserService.getCurrentUser().getUser().getId());
+        availability1.setDay("Monday");
+        availability1.setStartTime("9:00AM");
+        availability1.setEndTime("5:00PM");
+        availability1.setNotes("Available all day");
+        
+        long xd = 1;
+        when(driverAvailabilityRepository.findAllByDriverId(currentUserService.getCurrentUser().getUser().getId())).thenReturn(List.of(availability1));
+
+
+        // act
+        MvcResult response = mockMvc.perform(get("/api/driverAvailability"))
+                        .andExpect(status().isOk()).andReturn();
+
+
+        // assert
+        // verify(driverAvailabilityRepository, times(1)).findById(currentUserService.getCurrentUser().getUser().getId());
+        String expectedJson = mapper.writeValueAsString(List.of(availability1));
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
 }
 

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityControllerTests.java
@@ -240,7 +240,7 @@ public class DriverAvailabilityControllerTests extends ControllerTestCase {
         // arrange
         DriverAvailability availability = new DriverAvailability();
         availability.setId(0L); // Assuming the ID is set after save operation
-        availability.setDriverId(currentUserService.getCurrentUser().getUser().getId());
+        availability.setDriverId(11L);
         availability.setDay("Monday");
         availability.setStartTime("9:00AM");
         availability.setEndTime("5:00PM");
@@ -283,23 +283,32 @@ public class DriverAvailabilityControllerTests extends ControllerTestCase {
         // arrange
         DriverAvailability availability1 = new DriverAvailability();
         availability1.setId(1L);
-        availability1.setDriverId(currentUserService.getCurrentUser().getUser().getId());
+        availability1.setDriverId(1L);
         availability1.setDay("Monday");
         availability1.setStartTime("9:00AM");
         availability1.setEndTime("5:00PM");
         availability1.setNotes("Available all day");
-        
+        User testUser = User.builder()
+                .id(1L)
+                .email("capo@gmail.com")
+                .admin(true)
+                .driver(true)
+                .build();
+        CurrentUser currentUser = CurrentUser.builder()
+                .user(testUser)
+                .build();
+
+        when(currentUserService.getCurrentUser()).thenReturn(currentUser);
         long xd = 1;
-        when(driverAvailabilityRepository.findAllByDriverId(currentUserService.getCurrentUser().getUser().getId())).thenReturn(List.of(availability1));
+        when(driverAvailabilityRepository.findAllByDriverId(1L)).thenReturn(List.of(availability1));
 
 
         // act
-        MvcResult response = mockMvc.perform(get("/api/driverAvailability"))
+        MvcResult response = mockMvc.perform(get("/api/driverAvailability").with(csrf()))
                         .andExpect(status().isOk()).andReturn();
 
 
         // assert
-        // verify(driverAvailabilityRepository, times(1)).findById(currentUserService.getCurrentUser().getUser().getId());
         String expectedJson = mapper.writeValueAsString(List.of(availability1));
         String responseString = response.getResponse().getContentAsString();
         assertEquals(expectedJson, responseString);

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityControllerTests.java
@@ -240,7 +240,7 @@ public class DriverAvailabilityControllerTests extends ControllerTestCase {
         // arrange
         DriverAvailability availability = new DriverAvailability();
         availability.setId(0L); // Assuming the ID is set after save operation
-        availability.setDriverId(11L);
+        availability.setDriverId(currentUserService.getCurrentUser().getUser().getId());
         availability.setDay("Monday");
         availability.setStartTime("9:00AM");
         availability.setEndTime("5:00PM");
@@ -270,6 +270,5 @@ public class DriverAvailabilityControllerTests extends ControllerTestCase {
         String responseString = response.getResponse().getContentAsString();
         assertEquals(expectedJson, responseString);
     }
-
 }
 


### PR DESCRIPTION
In this pr, I added get all endpoint for driver availabilities controller.

###  DriverAvailabilityController

- [x] There is an endpoint `GET /api/driverAvailability` that gets all availability submissions for the current user.
- [x] Test for the API endpoint GET all

![image](https://github.com/ucsb-cs156-w24/proj-gauchoride-w24-7pm-3/assets/48678145/edb65dd0-7859-478a-a483-836a031156d1)

close #46 