### PR TITLE
Driver Availability: Add controller GET by id endpoint for driver availability

### DIFF
--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityController.java
@@ -87,7 +87,7 @@ public class DriverAvailabilityController extends ApiController {
     }
 
     @Operation(summary = "Delete an availability if owned by current user")
-    @PreAuthorize("hasRole('ROLE_USER')")
+    @PreAuthorize("hasRole('ROLE_DRIVER')")
     @DeleteMapping("")
     public Object deleteDriverAvailability(
         @Parameter(name="id", description="long, Id of the DriverAvailability to be deleted", 
@@ -102,7 +102,7 @@ public class DriverAvailabilityController extends ApiController {
         return genericMessage("DriverAvailability with id %s deleted".formatted(id));
     }
     @Operation(summary = "List all availabilities of current user")
-    @PreAuthorize("hasRole('ROLE_USER')")
+    @PreAuthorize("hasRole('ROLE_DRIVER')")
     @GetMapping("")
     public Iterable<DriverAvailability> allUserDriverAvailabilities() {
         Iterable<DriverAvailability> availabilities;
@@ -111,7 +111,7 @@ public class DriverAvailabilityController extends ApiController {
     }
 
     @Operation(summary = "Get a single availability by id, if user owns it")
-    @PreAuthorize("hasRole('ROLE_USER')")
+    @PreAuthorize("hasRole('ROLE_DRIVER')")
     @GetMapping("/id")
     public DriverAvailability getById(
             @Parameter(name="id", description = "long, Id of the DriverAvailability to get", 

--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityController.java
@@ -28,7 +28,6 @@ import javax.validation.Valid;
 @Tag(name = "DriverAvailability Request")
 @RequestMapping("/api/driverAvailability")
 @RestController
-
 public class DriverAvailabilityController extends ApiController {
 
     @Autowired
@@ -102,5 +101,14 @@ public class DriverAvailabilityController extends ApiController {
         
         return genericMessage("DriverAvailability with id %s deleted".formatted(id));
     }
+    @Operation(summary = "List all availabilities of current user")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public Iterable<DriverAvailability> allUserDriverAvailabilities() {
+        Iterable<DriverAvailability> availabilities;
+        availabilities = driverAvailabilityRepository.findAllByDriverId(getCurrentUser().getUser().getId());
+        return availabilities;
+    }
+
 }
 

--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityController.java
@@ -110,5 +110,18 @@ public class DriverAvailabilityController extends ApiController {
         return availabilities;
     }
 
+    @Operation(summary = "Get a single availability by id, if user owns it")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/id")
+    public DriverAvailability getById(
+            @Parameter(name="id", description = "long, Id of the DriverAvailability to get", 
+            required = true)  
+            @RequestParam Long id) {
+        DriverAvailability driverAvailability;
+        driverAvailability = driverAvailabilityRepository.findByIdAndDriverId(id, getCurrentUser().getUser().getId())
+                .orElseThrow(() -> new EntityNotFoundException(DriverAvailability.class, id));;
+        return driverAvailability;
+    }
+
 }
 

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityControllerTests.java
@@ -270,5 +270,39 @@ public class DriverAvailabilityControllerTests extends ControllerTestCase {
         String responseString = response.getResponse().getContentAsString();
         assertEquals(expectedJson, responseString);
     }
+
+    @Test
+    public void kappachungusfailshahahalol() throws Exception {
+            mockMvc.perform(get("/api/driverAvailability"))
+                            .andExpect(status().is(403)); // logged out users can't get all
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void hehehhahah() throws Exception {
+        // arrange
+        DriverAvailability availability1 = new DriverAvailability();
+        availability1.setId(1L);
+        availability1.setDriverId(currentUserService.getCurrentUser().getUser().getId());
+        availability1.setDay("Monday");
+        availability1.setStartTime("9:00AM");
+        availability1.setEndTime("5:00PM");
+        availability1.setNotes("Available all day");
+        
+        long xd = 1;
+        when(driverAvailabilityRepository.findAllByDriverId(currentUserService.getCurrentUser().getUser().getId())).thenReturn(List.of(availability1));
+
+
+        // act
+        MvcResult response = mockMvc.perform(get("/api/driverAvailability"))
+                        .andExpect(status().isOk()).andReturn();
+
+
+        // assert
+        // verify(driverAvailabilityRepository, times(1)).findById(currentUserService.getCurrentUser().getUser().getId());
+        String expectedJson = mapper.writeValueAsString(List.of(availability1));
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
 }
 

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityControllerTests.java
@@ -270,6 +270,5 @@ public class DriverAvailabilityControllerTests extends ControllerTestCase {
         String responseString = response.getResponse().getContentAsString();
         assertEquals(expectedJson, responseString);
     }
-
 }
 

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityControllerTests.java
@@ -283,15 +283,27 @@ public class DriverAvailabilityControllerTests extends ControllerTestCase {
         // arrange
         DriverAvailability availability1 = new DriverAvailability();
         availability1.setId(1L);
-        availability1.setDriverId(currentUserService.getCurrentUser().getUser().getId());
+        availability1.setDriverId(1L);
         availability1.setDay("Monday");
         availability1.setStartTime("9:00AM");
         availability1.setEndTime("5:00PM");
         availability1.setNotes("Available all day");
         
         long xd = 1;
-        when(driverAvailabilityRepository.findAllByDriverId(currentUserService.getCurrentUser().getUser().getId())).thenReturn(List.of(availability1));
+        when(driverAvailabilityRepository.findAllByDriverId(1L)).thenReturn(List.of(availability1));
 
+        User testUser = User.builder()
+                .id(1L)
+                .email("capo@gmail.com")
+                .admin(true)
+                .driver(true)
+                .build();
+
+        CurrentUser currentUser = CurrentUser.builder()
+                .user(testUser)
+                .build();
+
+        when(currentUserService.getCurrentUser()).thenReturn(currentUser);
 
         // act
         MvcResult response = mockMvc.perform(get("/api/driverAvailability"))
@@ -322,8 +334,20 @@ public class DriverAvailabilityControllerTests extends ControllerTestCase {
         availability1.setEndTime("5:00PM");
         availability1.setNotes("Available all day");
         
+        User testUser = User.builder()
+        .id(1L)
+        .email("capo@gmail.com")
+        .admin(true)
+        .driver(true)
+        .build();
+
+        CurrentUser currentUser = CurrentUser.builder()
+                .user(testUser)
+                .build();
+
+        when(currentUserService.getCurrentUser()).thenReturn(currentUser);
         long xd = 1;
-        when(driverAvailabilityRepository.findByIdAndDriverId(1L, currentUserService.getCurrentUser().getUser().getId())).thenReturn(Optional.of(availability1));
+        when(driverAvailabilityRepository.findByIdAndDriverId(1L, 1L)).thenReturn(Optional.of(availability1));
 
         // act
         MvcResult response = mockMvc.perform(get("/api/driverAvailability/id?id=1"))
@@ -341,6 +365,18 @@ public class DriverAvailabilityControllerTests extends ControllerTestCase {
     public void holymolyomah    () throws Exception {
         // Arrange: Mock the repository to return an empty Optional when findById is called
         when(driverAvailabilityRepository.findByIdAndDriverId(anyLong(), anyLong())).thenReturn(Optional.empty());
+
+        User testUser = User.builder()
+                .id(1L)
+                .email("capo@gmail.com")
+                .admin(true)
+                .driver(true)
+                .build();
+        CurrentUser currentUser = CurrentUser.builder()
+                .user(testUser)
+                .build();
+
+        when(currentUserService.getCurrentUser()).thenReturn(currentUser);
 
         mockMvc.perform(get("/api/driverAvailability/id?id=1")) 
                 .andExpect(status().isNotFound()).andReturn();

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityControllerTests.java
@@ -304,5 +304,46 @@ public class DriverAvailabilityControllerTests extends ControllerTestCase {
         String responseString = response.getResponse().getContentAsString();
         assertEquals(expectedJson, responseString);
     }
+        @Test
+    public void getByIdFails() throws Exception {
+            mockMvc.perform(get("/api/driverAvailability/id?id=177012"))
+                            .andExpect(status().is(403)); // logged out users can't get all
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void usergetbyidworks() throws Exception {
+        // arrange
+        DriverAvailability availability1 = new DriverAvailability();
+        availability1.setId(1L);
+        availability1.setDriverId(1L);
+        availability1.setDay("Monday");
+        availability1.setStartTime("9:00AM");
+        availability1.setEndTime("5:00PM");
+        availability1.setNotes("Available all day");
+        
+        long xd = 1;
+        when(driverAvailabilityRepository.findByIdAndDriverId(1L, currentUserService.getCurrentUser().getUser().getId())).thenReturn(Optional.of(availability1));
+
+        // act
+        MvcResult response = mockMvc.perform(get("/api/driverAvailability/id?id=1"))
+                        .andExpect(status().isOk()).andReturn();
+
+        // assert
+        // verify(driverAvailabilityRepository, times(1)).findByIdAndDriverId(1L, currentUserService.getCurrentUser().getUser().getId());
+        String expectedJson = mapper.writeValueAsString(availability1);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+
+    @Test
+    @WithMockUser(roles = "USER") // Mock an admin user
+    public void holymolyomah    () throws Exception {
+        // Arrange: Mock the repository to return an empty Optional when findById is called
+        when(driverAvailabilityRepository.findByIdAndDriverId(anyLong(), anyLong())).thenReturn(Optional.empty());
+
+        mockMvc.perform(get("/api/driverAvailability/id?id=1")) 
+                .andExpect(status().isNotFound()).andReturn();
+    }
 }
 


### PR DESCRIPTION
In this pr, I added the get by id endpoint for driver availability controller

###  DriverAvailabilityController

- [x] `GET /api/driverAvailability?id=123` that gets an availability submission if owned by the current user.
- [x] Test for the API endpoint GET by id
![image](https://github.com/ucsb-cs156-w24/proj-gauchoride-w24-7pm-3/assets/48678145/8aa3dbfa-58f7-4d79-bedb-f9d1b840e96e)

close #45 