### PR TITLE
Profile Page Badge Spacing

### DIFF
--- a/frontend/src/main/components/Profile/RoleBadge.js
+++ b/frontend/src/main/components/Profile/RoleBadge.js
@@ -8,7 +8,7 @@ export default function RoleBadge({role, currentUser}) {
   const lcrole = role.replace("ROLE_","").toLowerCase();
   return (
      roles.includes(role) ?
-        <Badge className="bg-primary" data-testid={`role-badge-${lcrole}`}>{lcrole}</Badge> 
+        <Badge style = {{margin: '0 5px'}} className="bg-primary" data-testid={`role-badge-${lcrole}`}>{lcrole}</Badge> 
         :
         <span data-testid={`role-missing-${lcrole}`}></span>
   );

--- a/frontend/src/main/pages/ProfilePage.js
+++ b/frontend/src/main/pages/ProfilePage.js
@@ -86,25 +86,12 @@ const ProfilePage = () => {
                 <Col md>
                     <h2>{fullName}</h2>
                     <p className="lead text-muted">{email}</p>
-        
-                    <div style={{ display: 'flex', justifyContent: 'center' }}>
                       {/* Each RoleBadge wrapped in a div with left and right margins */}
-                      <div style={{ margin: '0 5px' }}>
                           <RoleBadge role={"ROLE_USER"} currentUser={currentUser} />
-                      </div>
-                      <div style={{ margin: '0 5px' }}>
                           <RoleBadge role={"ROLE_MEMBER"} currentUser={currentUser} />
-                      </div>
-                      <div style={{ margin: '0 5px' }}>
                           <RoleBadge role={"ROLE_ADMIN"} currentUser={currentUser} />
-                      </div>
-                      <div style={{ margin: '0 5px' }}>
                           <RoleBadge role={"ROLE_DRIVER"} currentUser={currentUser} />
-                      </div>
-                      <div style={{ margin: '0 5px' }}>
                           <RoleBadge role={"ROLE_RIDER"} currentUser={currentUser} />
-                      </div>
-                  </div>
                     <p></p>
                     <>
                     <p className="lead text-muted" >{"cell phone number: "} {whichNumber ? (updatedPhoneNumber ? updatedPhoneNumber : "N/A") : (cellPhone ? cellPhone : "N/A")}</p>

--- a/frontend/src/main/pages/ProfilePage.js
+++ b/frontend/src/main/pages/ProfilePage.js
@@ -87,12 +87,24 @@ const ProfilePage = () => {
                     <h2>{fullName}</h2>
                     <p className="lead text-muted">{email}</p>
         
-                    
-                    <RoleBadge role={"ROLE_USER"} currentUser={currentUser}/>
-                    <RoleBadge role={"ROLE_MEMBER"} currentUser={currentUser}/>
-                    <RoleBadge role={"ROLE_ADMIN"} currentUser={currentUser}/>
-                    <RoleBadge role={"ROLE_DRIVER"} currentUser={currentUser}/>
-                    <RoleBadge role={"ROLE_RIDER"} currentUser={currentUser}/>
+                    <div style={{ display: 'flex', justifyContent: 'center' }}>
+                      {/* Each RoleBadge wrapped in a div with left and right margins */}
+                      <div style={{ margin: '0 5px' }}>
+                          <RoleBadge role={"ROLE_USER"} currentUser={currentUser} />
+                      </div>
+                      <div style={{ margin: '0 5px' }}>
+                          <RoleBadge role={"ROLE_MEMBER"} currentUser={currentUser} />
+                      </div>
+                      <div style={{ margin: '0 5px' }}>
+                          <RoleBadge role={"ROLE_ADMIN"} currentUser={currentUser} />
+                      </div>
+                      <div style={{ margin: '0 5px' }}>
+                          <RoleBadge role={"ROLE_DRIVER"} currentUser={currentUser} />
+                      </div>
+                      <div style={{ margin: '0 5px' }}>
+                          <RoleBadge role={"ROLE_RIDER"} currentUser={currentUser} />
+                      </div>
+                  </div>
                     <p></p>
                     <>
                     <p className="lead text-muted" >{"cell phone number: "} {whichNumber ? (updatedPhoneNumber ? updatedPhoneNumber : "N/A") : (cellPhone ? cellPhone : "N/A")}</p>

--- a/frontend/src/tests/components/Profile/RoleBadge.test.js
+++ b/frontend/src/tests/components/Profile/RoleBadge.test.js
@@ -9,6 +9,12 @@ describe("RoleBadge tests", () => {
             <RoleBadge currentUser={currentUserFixtures.userOnly} role={"ROLE_USER"} />
         );
         await waitFor( ()=> expect(getByTestId("role-badge-user")).toBeInTheDocument() );
+
+        // Check if the badge has the correct margin style
+        const badge = getByTestId("role-badge-user");
+        await waitFor(() => expect(badge).toBeInTheDocument());
+        const badgeStyle = getComputedStyle(badge);
+        expect(badgeStyle.margin).toBe("0px 5px");
     });
 
     test("renders without crashing for ROLE_DRIVER when user has ROLE_DRIVER", async () => {
@@ -44,5 +50,29 @@ describe("RoleBadge tests", () => {
             <RoleBadge currentUser={currentUserFixtures.driverOnly} role={""} />
         );
         await waitFor( ()=> expect(getByTestId("role-missing-")).toBeInTheDocument() );
+    });
+
+
+
+    // Additional test cases for roles
+    test("renders without crashing for ROLE_USER when user does NOT have ROLE_USER", async () => {
+        const { getByTestId } = render(
+            <RoleBadge currentUser={currentUserFixtures.driverOnly} role={"ROLE_USER"} />
+        );
+        await waitFor(() => expect(getByTestId("role-missing-user")).toBeInTheDocument());
+    });
+
+    test("renders without crashing for ROLE_ADMIN when user has ROLE_ADMIN", async () => {
+        const { getByTestId } = render(
+            <RoleBadge currentUser={currentUserFixtures.adminUser} role={"ROLE_ADMIN"} />
+        );
+        await waitFor(() => expect(getByTestId("role-badge-admin")).toBeInTheDocument());
+    });
+
+    test("renders without crashing for ROLE_ADMIN when user does NOT have ROLE_ADMIN", async () => {
+        const { getByTestId } = render(
+            <RoleBadge currentUser={currentUserFixtures.driverOnly} role={"ROLE_ADMIN"} />
+        );
+        await waitFor(() => expect(getByTestId("role-missing-admin")).toBeInTheDocument());
     });
 });


### PR DESCRIPTION
Fixed the badge spacing by adding flexbox properties on the user profile page to (1) ensure readability for users and (2) fix the issue of the user's profile image not being visible due to spacing issues.

Before:
![image](https://github.com/ucsb-cs156-w24/proj-gauchoride-w24-7pm-3/assets/37479437/6b1baa50-f5fb-4263-81f3-3d99319dca11)

After:
![image](https://github.com/ucsb-cs156-w24/proj-gauchoride-w24-7pm-3/assets/37479437/0c513abd-3c6d-4a68-8053-5c2d6f495d93)


Closes #58