### PR TITLE
Driver Availability: Add controller DELETE endpoint for driver availability

### DIFF
--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityController.java
@@ -53,4 +53,20 @@ public class DriverAvailabilityController extends ApiController {
                 .orElseThrow(() -> new EntityNotFoundException(DriverAvailability.class, id));;
         return driverAvailability;
     }
+
+    @Operation(summary = "Delete an availability if owned by current user")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @DeleteMapping("")
+    public Object deleteDriverAvailability(
+        @Parameter(name="id", description="long, Id of the DriverAvailability to be deleted", 
+        required = true) @RequestParam long id) {
+
+        DriverAvailability availability;
+
+        availability = driverAvailabilityRepository.findByIdAndDriverId(id, getCurrentUser().getUser().getId())
+            .orElseThrow(() -> new EntityNotFoundException(DriverAvailability.class, id));
+        driverAvailabilityRepository.delete(availability);
+        
+        return genericMessage("DriverAvailability with id %s deleted".formatted(id));
+    }
 }

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityControllerTests.java
@@ -1,11 +1,18 @@
 package edu.ucsb.cs156.gauchoride.controllers;
 
 import edu.ucsb.cs156.gauchoride.entities.DriverAvailability;
+import edu.ucsb.cs156.gauchoride.entities.User;
+import edu.ucsb.cs156.gauchoride.models.CurrentUser;
 import edu.ucsb.cs156.gauchoride.repositories.DriverAvailabilityRepository;
 import edu.ucsb.cs156.gauchoride.testconfig.TestConfig;
 import edu.ucsb.cs156.gauchoride.ControllerTestCase;
 import java.util.*;
+
+import javax.swing.text.html.Option;
+
 import java.lang.*;
+
+import org.checkerframework.checker.nullness.Opt;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -14,16 +21,17 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MvcResult;
 
-import java.util.List;
-import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import edu.ucsb.cs156.gauchoride.repositories.UserRepository;
+import edu.ucsb.cs156.gauchoride.services.CurrentUserService;
+
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 
 @WebMvcTest(controllers = DriverAvailabilityController.class)
@@ -36,17 +44,20 @@ public class DriverAvailabilityControllerTests extends ControllerTestCase {
     @MockBean
     private UserRepository UserRepository;
 
+    @MockBean
+    private CurrentUserService currentUserService;
+
     @Test
     public void logged_out_users_cannot_get_all() throws Exception {
-            mockMvc.perform(get("/api/driverAvailability/admin/all"))
-                            .andExpect(status().is(403)); // logged out users can't get all
+        mockMvc.perform(get("/api/driverAvailability/admin/all"))
+                .andExpect(status().is(403)); // logged out users can't get all
     }
 
     @WithMockUser(roles = { "ADMIN" })
     @Test
     public void logged_in_users_can_get_all() throws Exception {
-            mockMvc.perform(get("/api/driverAvailability/admin/all"))
-                            .andExpect(status().is(200)); // logged
+        mockMvc.perform(get("/api/driverAvailability/admin/all"))
+                .andExpect(status().is(200)); // logged
     }
 
     @WithMockUser(roles = { "ADMIN" })
@@ -54,6 +65,7 @@ public class DriverAvailabilityControllerTests extends ControllerTestCase {
     public void getByIdAdminFailsWhenThingDoesntExist() {
 
     }
+
     @WithMockUser(roles = { "ADMIN" })
     @Test
     public void logged_in_admin_can_get_all_driver_availability() throws Exception {
@@ -81,7 +93,7 @@ public class DriverAvailabilityControllerTests extends ControllerTestCase {
 
         // act
         MvcResult response = mockMvc.perform(get("/api/driverAvailability/admin/all"))
-                        .andExpect(status().isOk()).andReturn();
+                .andExpect(status().isOk()).andReturn();
 
         // assert
         verify(driverAvailabilityRepository, times(1)).findAll();
@@ -89,6 +101,7 @@ public class DriverAvailabilityControllerTests extends ControllerTestCase {
         String responseString = response.getResponse().getContentAsString();
         assertEquals(expectedJson, responseString);
     }
+
     @WithMockUser(roles = { "ADMIN" })
     @Test
     public void admingetbyidworks() throws Exception {
@@ -100,13 +113,13 @@ public class DriverAvailabilityControllerTests extends ControllerTestCase {
         availability1.setStartTime("9:00AM");
         availability1.setEndTime("5:00PM");
         availability1.setNotes("Available all day");
-        
+
         long xd = 1;
         when(driverAvailabilityRepository.findById(xd)).thenReturn(Optional.of(availability1));
 
         // act
         MvcResult response = mockMvc.perform(get("/api/driverAvailability/admin?id=1"))
-                        .andExpect(status().isOk()).andReturn();
+                .andExpect(status().isOk()).andReturn();
 
         // assert
         verify(driverAvailabilityRepository, times(1)).findById(xd);
@@ -115,14 +128,77 @@ public class DriverAvailabilityControllerTests extends ControllerTestCase {
         assertEquals(expectedJson, responseString);
     }
 
-
     @Test
     @WithMockUser(roles = "ADMIN") // Mock an admin user
     public void getByIdAdmin_ShouldReturnNotFoundIfItemDoesNotExist() throws Exception {
-        // Arrange: Mock the repository to return an empty Optional when findById is called
+        // Arrange: Mock the repository to return an empty Optional when findById is
+        // called
         when(driverAvailabilityRepository.findById(anyLong())).thenReturn(Optional.empty());
 
-        mockMvc.perform(get("/api/driverAvailability/admin?id=1")) 
+        mockMvc.perform(get("/api/driverAvailability/admin?id=1"))
                 .andExpect(status().isNotFound()).andReturn();
     }
+
+    // Tests for DELETE /api/driverAvailability?id=...
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void user_can_delete_availability() throws Exception {
+        // arrange
+
+        DriverAvailability driverAvailability = DriverAvailability.builder()
+                .id(12)
+                .driverId(13L)
+                .day("Monday")
+                .startTime("11:00AM")
+                .endTime("11:30AM")
+                .build();
+
+        User testUser = User.builder()
+                .id(13L)
+                .email("capo@gmail.com")
+                .admin(true)
+                .driver(true)
+                .build();
+        CurrentUser currentUser = CurrentUser.builder()
+                .user(testUser)
+                .build();
+
+        when(currentUserService.getCurrentUser()).thenReturn(currentUser);
+        when(driverAvailabilityRepository.findByIdAndDriverId(eq(12L), eq(13L))).thenReturn(Optional.of(driverAvailability));
+
+        // act
+        MvcResult response = mockMvc.perform(
+                delete("/api/driverAvailability?id=12")
+                        .with(csrf()))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(driverAvailabilityRepository, times(1)).findByIdAndDriverId(12L, 13L);
+        verify(driverAvailabilityRepository, times(1)).delete(any());
+
+        Map<String, Object> json = responseToJson(response);
+        assertEquals("DriverAvailability with id 12 deleted", json.get("message"));
+    }
+
+    // @WithMockUser(roles = { "ADMIN", "USER" })
+    // @Test
+    // public void user_cannot_delete_availbility_not_owned()
+    //         throws Exception {
+    //     // arrange
+
+    //     when(driverAvailabilityRepository.findById(eq(457L))).thenReturn(Optional.empty());
+
+    //     // act
+    //     MvcResult response = mockMvc.perform(
+    //             delete("/api/driverAvailability?id=457")
+    //                     .with(csrf()))
+    //             .andExpect(status().isNotFound()).andReturn();
+
+    //     // assert
+    //     verify(driverAvailabilityRepository, times(1)).findById(457L);
+    //     Map<String, Object> json = responseToJson(response);
+    //     assertEquals("UCSBOrganizations with id 457 not found", json.get("message"));
+    // }
+
 }

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityControllerTests.java
@@ -181,24 +181,44 @@ public class DriverAvailabilityControllerTests extends ControllerTestCase {
         assertEquals("DriverAvailability with id 12 deleted", json.get("message"));
     }
 
-    // @WithMockUser(roles = { "ADMIN", "USER" })
-    // @Test
-    // public void user_cannot_delete_availbility_not_owned()
-    //         throws Exception {
-    //     // arrange
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void user_cannot_delete_availbility_not_owned()
+            throws Exception {
+        // arrange
+        DriverAvailability driverAvailability = DriverAvailability.builder()
+                .id(12)
+                .driverId(13L)
+                .day("Monday")
+                .startTime("11:00AM")
+                .endTime("11:30AM")
+                .build();
 
-    //     when(driverAvailabilityRepository.findById(eq(457L))).thenReturn(Optional.empty());
+        User testUser = User.builder()
+                .id(11L)
+                .email("capo@gmail.com")
+                .admin(true)
+                .driver(true)
+                .build();
+        CurrentUser currentUser = CurrentUser.builder()
+                .user(testUser)
+                .build();
 
-    //     // act
-    //     MvcResult response = mockMvc.perform(
-    //             delete("/api/driverAvailability?id=457")
-    //                     .with(csrf()))
-    //             .andExpect(status().isNotFound()).andReturn();
+        when(currentUserService.getCurrentUser()).thenReturn(currentUser);
+        when(driverAvailabilityRepository.findByIdAndDriverId(eq(12L), eq(13L))).thenReturn(Optional.of(driverAvailability));
 
-    //     // assert
-    //     verify(driverAvailabilityRepository, times(1)).findById(457L);
-    //     Map<String, Object> json = responseToJson(response);
-    //     assertEquals("UCSBOrganizations with id 457 not found", json.get("message"));
-    // }
+        // act
+        MvcResult response = mockMvc.perform(
+                delete("/api/driverAvailability?id=12")
+                        .with(csrf()))
+                .andExpect(status().isNotFound()).andReturn();
+
+        // assert
+        verify(driverAvailabilityRepository, times(1)).findByIdAndDriverId(12L, 11L);
+        verify(driverAvailabilityRepository, times(0)).delete(any());
+
+        Map<String, Object> json = responseToJson(response);
+        assertEquals("DriverAvailability with id 12 not found", json.get("message"));
+    }
 
 }


### PR DESCRIPTION
This pull request adds a new DELETE endpoint /api/driverAvailability to the API, enabling users to delete their own availability records. The endpoint specifically targets availability entries owned by the current user, enhancing the control and management of their availability status. This addition streamlines the process of removing outdated or no longer relevant availability information, contributing to a more efficient and user-friendly system.

Closes #44 